### PR TITLE
Updated bulk command to sign headers.

### DIFF
--- a/lib/elastic/http.ex
+++ b/lib/elastic/http.ex
@@ -83,8 +83,12 @@ defmodule Elastic.HTTP do
   def bulk(options) do
     headers = Keyword.get(options, :headers, [])
     body = Keyword.get(options, :body, "") <> "\n"
-    options = Keyword.put(options, :body, body)
     url = URI.merge(base_url(), "_bulk")
+    headers = build_auth_header(:post, url, headers, body)
+    options = options
+    |> Keyword.put(:body, body)
+    |> Keyword.put(:headers, headers)
+
     HTTPotion.post(url, options) |> process_response
   end
 


### PR DESCRIPTION
`Bulk.create` was giving a 403 on aws.

This change makes use of the `build_auth_header` that regular requests have
to authenticate bulk create calls.