### PR TITLE
Support passing options when updating a document.

### DIFF
--- a/lib/elastic/document.ex
+++ b/lib/elastic/document.ex
@@ -8,9 +8,9 @@ defmodule Elastic.Document do
     document_path(index, type, id) |> HTTP.put(body: data)
   end
 
-  def update(index, type, id, data) do
+  def update(index, type, id, data, options \\ []) do
     data = %{doc: data}
-    update_path(index, type, id)
+    update_path(index, type, id, options)
     |> HTTP.post(body: data)
   end
 
@@ -26,8 +26,8 @@ defmodule Elastic.Document do
     "#{index_name(index)}/#{type}/#{id}"
   end
 
-  def update_path(index, type, id) do
-    document_path(index, type, id) <> "/_update"
+  def update_path(index, type, id, options \\ []) do
+    document_path(index, type, id) <> "/_update?" <> URI.encode_query(options)
   end
 
   defp index_name(index) do

--- a/lib/elastic/document/api.ex
+++ b/lib/elastic/document/api.ex
@@ -160,8 +160,8 @@ defmodule Elastic.Document.API do
         Document.index(es_index, @es_type, id, data)
       end
 
-      def update(id, data, es_index \\ @es_index) do
-        Document.update(es_index, @es_type, id, data)
+      def update(id, data, es_index \\ @es_index, options \\ []) do
+        Document.update(es_index, @es_type, id, data, options)
       end
 
       def get(id, es_index \\ @es_index) do

--- a/test/elastic/integration/document/api_test.exs
+++ b/test/elastic/integration/document/api_test.exs
@@ -112,6 +112,14 @@ defmodule Elastic.Document.APITest do
   end
 
   @tag integration: true
+  test "puts + updates a document in explicit index with conflict handling" do
+    Question.index(1, %{text: "Hello world!"}, "some_index")
+    {:ok, 200, _} = Question.update(1, %{comments: 5}, "some_index", retry_on_conflict: 10)
+    answer = Question.get(1, "some_index")
+    assert answer == %Question{id: "1", text: "Hello world!", comments: 5}
+  end
+
+  @tag integration: true
   test "puts + deletes a document from explicit index" do
     Question.index(1, %{text: "Hello world!"}, "some_index")
     Question.delete(1, "some_index")


### PR DESCRIPTION
This will allow passing options that the update API supports such as `retry_on_conflict`.